### PR TITLE
Fix overlay hiding so VR button appears

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
   </style>
 </head>
 <body>
-  <div id="overlay">Use a WebXR‑enabled browser or VR headset for the full experience.</div>
+  <div id="overlay">Use a WebXR‑enabled browser or VR headset for the full experience. When ready, press “Enter VR”.</div>
   <script type="module" src="./scripts/main.js"></script>
 </body>
 </html>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -42,6 +42,18 @@ async function init() {
   document.body.appendChild(renderer.domElement);
   document.body.appendChild(VRButton.createButton(renderer));
 
+  // If XR is supported, remove the overlay hint so the VR button is visible.
+  const overlay = document.getElementById('overlay');
+  if (overlay && navigator.xr && navigator.xr.isSessionSupported) {
+    navigator.xr.isSessionSupported('immersive-vr').then((supported) => {
+      if (supported) {
+        overlay.remove();
+      }
+    }).catch(() => {
+      /* ignore */
+    });
+  }
+
   // Scene
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(0x000010);


### PR DESCRIPTION
## Summary
- hide the introductory overlay when WebXR support is detected so it doesn't obscure the VR button
- tweak the overlay message to mention the 'Enter VR' button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687edd57274c8331b9776627e2c315bc