### PR TITLE
Fix XR initialization module resolution

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,13 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.155.0/build/three.module.js"
+      }
+    }
+  </script>
   <style>
     body {
       margin: 0;


### PR DESCRIPTION
## Summary
- add an import map so the `three` module can be resolved in browsers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ee2856ed88331a1623f7c2a41de1d