### PR TITLE
Add TTS fun facts with positional audio

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -113,7 +113,7 @@ async function init() {
   cockpit.group.add(controlLight);
 
   // === Audio System ===
-  const audio = await initAudio(camera);
+  const audio = await initAudio(camera, cockpit.dashboard);
 
   // === UI System ===
   const ui = createUI(
@@ -131,7 +131,8 @@ async function init() {
         launchProbe(launchPosition, aimDirection, ui.probeLaunchSpeed, ui.probeMass, scene);
         if (audio) audio.playBeep();
     },
-    (enabled) => { autopilotEnabled = enabled; }
+    (enabled) => { autopilotEnabled = enabled; },
+    (fact) => { if (audio) audio.speak(fact); }
   );
 
   // === Control System ===

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -16,7 +16,7 @@ import { C_KMPS, MPH_TO_KMPS } from './constants.js';
 const bgImage = new Image();
 bgImage.src = './textures/ui.png';
 
-export function createUI(dashboardPanel, onWarpSelect, onSpeedChange, onLaunchProbe, onToggleAutopilot) {
+export function createUI(dashboardPanel, onWarpSelect, onSpeedChange, onLaunchProbe, onToggleAutopilot, onFunFact) {
   // NEW: Using a larger canvas for the single dashboard layout
   const canvasSize = { width: 1024, height: 512 };
   const canvas = document.createElement('canvas');
@@ -216,6 +216,14 @@ export function createUI(dashboardPanel, onWarpSelect, onSpeedChange, onLaunchPr
     // Column 2: Info
     else if (x > 280 && x < 700) {
         state.funFactIndex++;
+        if (onFunFact) {
+          const body = solarBodies[state.infoBodyIndex] || solarBodies[0];
+          const facts = body.funFacts || [];
+          if (facts.length > 0) {
+            const fact = facts[state.funFactIndex % facts.length];
+            onFunFact(fact);
+          }
+        }
     }
     // Column 3: Sliders
     else if (x > 720 && x < 1000) {


### PR DESCRIPTION
## Summary
- attach positional sounds to the cockpit dashboard
- expose a speech helper via the audio module
- trigger speech when fun facts are cycled

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687f0648a02c8331860943b99a9613db