### PR TITLE
Add planet labels with toggle

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -141,6 +141,7 @@ async function init() {
         if (audio) audio.playBeep();
     },
     (enabled) => { autopilotEnabled = enabled; },
+    (visible) => { labelsVisible = visible; },
     (fact) => { if (audio) audio.speak(fact); }
   );
 
@@ -159,6 +160,7 @@ async function init() {
   let lastFrameTime = performance.now();
   let simulationTimeDays = 0;
   let autopilotEnabled = false;
+  let labelsVisible = true;
   let warpAnim = null;
 
   function warpToBody(bodyIndex) {
@@ -256,6 +258,12 @@ async function init() {
       const pos = new THREE.Vector3();
       b.group.getWorldPosition(pos);
       return pos;
+    });
+    bodies.forEach(b => {
+      if (b.group.userData.label) {
+        b.group.userData.label.quaternion.copy(camera.quaternion);
+        b.group.userData.label.visible = labelsVisible;
+      }
     });
     let closestBodyIndex = -1;
     let minDistanceSq = Infinity;

--- a/scripts/solarSystem.js
+++ b/scripts/solarSystem.js
@@ -33,6 +33,29 @@ const textures = {
   neptune: textureLoader.loadAsync('./textures/neptune.jpg'),
 };
 
+function createLabelSprite(text) {
+  const canvas = document.createElement('canvas');
+  const context = canvas.getContext('2d');
+  context.font = '64px Orbitron';
+  const metrics = context.measureText(text);
+  canvas.width = metrics.width + 40;
+  canvas.height = 80;
+  context.font = '64px Orbitron';
+  context.textAlign = 'center';
+  context.textBaseline = 'middle';
+  context.fillStyle = '#aaddff';
+  context.shadowColor = '#ffffff';
+  context.shadowBlur = 8;
+  context.fillText(text, canvas.width / 2, canvas.height / 2);
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.encoding = THREE.sRGBEncoding;
+  const material = new THREE.SpriteMaterial({ map: texture, transparent: true });
+  const sprite = new THREE.Sprite(material);
+  const scaleFactor = 0.05;
+  sprite.scale.set(canvas.width * scaleFactor, canvas.height * scaleFactor, 1);
+  return sprite;
+}
+
 /**
  * Creates a mesh for a celestial body, applying appropriate textures.
  * Special cases for Earth and Saturn are handled.
@@ -42,8 +65,13 @@ const textures = {
 async function buildBody(bodyData) {
   const group = new THREE.Group();
   group.name = bodyData.name;
-
+  
   const radiusWorld = (bodyData.radius / KM_PER_WORLD_UNIT) * SIZE_MULTIPLIER;
+  const label = createLabelSprite(bodyData.name);
+  label.position.set(0, radiusWorld * 1.3, 0);
+  group.add(label);
+  group.userData.label = label;
+
   const sphereGeom = new THREE.SphereGeometry(radiusWorld, 64, 64);
   let bodyMesh;
 

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -16,7 +16,7 @@ import { C_KMPS, MPH_TO_KMPS } from './constants.js';
 const bgImage = new Image();
 bgImage.src = './textures/ui.png';
 
-export function createUI(dashboardPanel, onWarpSelect, onSpeedChange, onLaunchProbe, onToggleAutopilot, onFunFact) {
+export function createUI(dashboardPanel, onWarpSelect, onSpeedChange, onLaunchProbe, onToggleAutopilot, onToggleLabels, onFunFact) {
   // NEW: Using a larger canvas for the single dashboard layout
   const canvasSize = { width: 1024, height: 512 };
   const canvas = document.createElement('canvas');
@@ -48,6 +48,7 @@ export function createUI(dashboardPanel, onWarpSelect, onSpeedChange, onLaunchPr
     probeMassFraction: 0.1, // 0-1 fraction for mass slider
     probeSpeedFraction: 0.1, // 0-1 fraction for speed slider
     autopilot: false,
+    labels: true,
     needsRedraw: true,
   };
 
@@ -170,6 +171,12 @@ export function createUI(dashboardPanel, onWarpSelect, onSpeedChange, onLaunchPr
     context.fillRect(col3X, 350, 120, 24);
     drawText(state.autopilot ? 'ON' : 'OFF', col3X + 10, 368, 16, '#ffffff');
 
+    // Labels Toggle
+    drawText('LABELS', col3X, 390, 16);
+    context.fillStyle = state.labels ? '#226622' : '#662222';
+    context.fillRect(col3X, 410, 120, 24);
+    drawText(state.labels ? 'ON' : 'OFF', col3X + 10, 428, 16, '#ffffff');
+
     texture.needsUpdate = true;
     state.needsRedraw = false;
   }
@@ -238,6 +245,10 @@ export function createUI(dashboardPanel, onWarpSelect, onSpeedChange, onLaunchPr
             state.autopilot = !state.autopilot;
             if (onToggleAutopilot) onToggleAutopilot(state.autopilot);
         }
+        else if (y > 400 && y < 434) {
+            state.labels = !state.labels;
+            if (onToggleLabels) onToggleLabels(state.labels);
+        }
     }
   }
 
@@ -253,6 +264,7 @@ export function createUI(dashboardPanel, onWarpSelect, onSpeedChange, onLaunchPr
     get probeMass() { return 10 + Math.pow(state.probeMassFraction, 3) * 1e6; },
     get probeLaunchSpeed() { return state.probeSpeedFraction * C_KMPS; },
     get autopilot() { return state.autopilot; },
-    get warpTargetIndex() { return state.warpTargetIndex; }
+    get warpTargetIndex() { return state.warpTargetIndex; },
+    get labelsVisible() { return state.labels; }
   };
 }


### PR DESCRIPTION
## Summary
- add label sprites for each celestial body
- make label visibility controllable from the dashboard
- propagate new label toggle through main loop

## Testing
- `node --check scripts/solarSystem.js`
- `node --check scripts/ui.js`
- `node --check scripts/main.js`


------
https://chatgpt.com/codex/tasks/task_e_687f0a23c13c833192c23335ab45bd0f