### PR TITLE
Fix VR cockpit orientation and hand models

### DIFF
--- a/scripts/cockpit.js
+++ b/scripts/cockpit.js
@@ -105,7 +105,9 @@ export function createDashboardCockpit() {
   const dashboard = new THREE.Mesh(dashboardGeom, dashboardMat);
   dashboard.name = "DashboardPanel";
   dashboard.position.set(0, 1.05, -0.65);
-  dashboard.rotation.set(-0.35, Math.PI, 0);
+  // Orient the dashboard so text isn't mirrored when viewed from inside
+  dashboard.rotation.set(-0.35, 0, 0);
+  dashboard.scale.z = -1; // flip to display correctly from the cockpit
   cockpitGroup.add(dashboard);
 
   // --- Side Consoles ---

--- a/scripts/controls.js
+++ b/scripts/controls.js
@@ -14,7 +14,8 @@ const GRAB_DISTANCE = 0.25; // Max distance to highlight/grab an object
 export function setupControls(renderer, scene, cockpit, ui, fireProbe) {
     const tempMatrix = new THREE.Matrix4();
     const controllerModelFactory = new XRControllerModelFactory();
-    const handModelFactory = new XRHandModelFactory().setPath("https://cdn.jsdelivr.net/npm/three@0.155.0/examples/models/fbx/");
+    // Use the default hand model path so hands load correctly
+    const handModelFactory = new XRHandModelFactory();
 
     // State for each controller/hand
     const controllers = [];


### PR DESCRIPTION
## Summary
- orient dashboard correctly so the UI is not mirrored
- rely on default path for hand models to ensure controllers show up

## Testing
- `node -c scripts/cockpit.js`
- `node -c scripts/controls.js`


------
https://chatgpt.com/codex/tasks/task_e_687f0faf5fd08331b9aa375d9a07be1a