### PR TITLE
Restyle cockpit with neon theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
       /* CHANGED: Restored the background image for the loading screen */
       background: #000 url('./textures/ui.png') no-repeat center center fixed;
       background-size: cover;
-      color: white;
+      color: #aaddff;
       font-family: 'Orbitron', sans-serif;
     }
     #overlay {
@@ -30,9 +30,10 @@
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
-      background: rgba(0,0,0,0.6);
+      background: rgba(0,20,30,0.6);
       padding: 20px 30px;
       border-radius: 8px;
+      border: 2px solid #1188bb;
       font-size: 16px;
       text-align: center;
       backdrop-filter: blur(4px);

--- a/scripts/cockpit.js
+++ b/scripts/cockpit.js
@@ -8,7 +8,11 @@
  * floor, and repositioned controls.  The throttle and joystick sit on low
  * pedestals beside the seat and the dashboard is a large plane directly in
  * front of the pilot.  The canopy and lighting remain mostly unchanged.
- */
+ *
+ * This second rework focuses on style.  Materials and lights now follow a
+ * cohesive blue‑neon theme and subtle glow elements were added around the
+ * dashboard to give the cockpit a high‑tech feel.
+*/
 
 import * as THREE from 'three';
 
@@ -26,23 +30,28 @@ export function createReworkedCockpit() {
   // Slightly larger overall scale for comfort
   cockpitGroup.scale.set(0.75, 0.75, 0.75);
 
+  const BASE_COLOR = 0x0e0e12;
+  const ACCENT_COLOR = 0x1188bb;
+  const GLOW_COLOR = 0x2299ee;
+  const SEAT_COLOR = 0x1b1f27;
+
   const darkMetalMat = new THREE.MeshStandardMaterial({
-    color: 0x1a1a20,
+    color: BASE_COLOR,
     metalness: 0.9,
     roughness: 0.3,
   });
   // Materials for new decorative elements
   const seatMat = new THREE.MeshStandardMaterial({
-    color: 0x222233,
-    metalness: 0.7,
+    color: SEAT_COLOR,
+    metalness: 0.6,
     roughness: 0.5,
   });
   const accentMat = new THREE.MeshStandardMaterial({
-    color: 0x224466,
-    metalness: 0.9,
+    color: ACCENT_COLOR,
+    metalness: 1.0,
     roughness: 0.2,
-    emissive: 0x112244,
-    emissiveIntensity: 0.5,
+    emissive: GLOW_COLOR,
+    emissiveIntensity: 0.6,
   });
 
   // --- Floor ---
@@ -62,7 +71,7 @@ export function createReworkedCockpit() {
   seatBase.position.set(0, 0.55, -0.25);
   const seatBack = new THREE.Mesh(new THREE.BoxGeometry(0.7, 0.9, 0.1), seatMat);
   seatBack.position.set(0, 1.0, -0.55);
-  const seatLeftArm = new THREE.Mesh(new THREE.BoxGeometry(0.1, 0.15, 0.6), seatMat);
+  const seatLeftArm = new THREE.Mesh(new THREE.BoxGeometry(0.1, 0.15, 0.6), accentMat);
   seatLeftArm.position.set(-0.4, 0.75, -0.3);
   const seatRightArm = seatLeftArm.clone();
   seatRightArm.position.set(0.4, 0.75, -0.3);
@@ -75,6 +84,17 @@ export function createReworkedCockpit() {
   floorRing.rotation.x = Math.PI / 2;
   floorRing.position.y = 0.01;
   cockpitGroup.add(floorRing);
+
+  const glowRingMat = new THREE.MeshBasicMaterial({
+    color: GLOW_COLOR,
+    transparent: true,
+    opacity: 0.25,
+    blending: THREE.AdditiveBlending,
+  });
+  const glowRing = new THREE.Mesh(new THREE.TorusGeometry(2.5, 0.05, 8, 32), glowRingMat);
+  glowRing.rotation.x = Math.PI / 2;
+  glowRing.position.y = 0.02;
+  cockpitGroup.add(glowRing);
 
   // --- Canopy ---
   // CHANGED: Enlarged and raised the canopy for better headroom.
@@ -92,16 +112,16 @@ export function createReworkedCockpit() {
 
   // --- Overhead Crossbar with Lights ---
   const crossbarGeom = new THREE.CylinderGeometry(0.02, 0.02, 2.2, 8);
-  const crossbar = new THREE.Mesh(crossbarGeom, darkMetalMat);
+  const crossbar = new THREE.Mesh(crossbarGeom, accentMat);
   crossbar.position.set(0, 2.2, -0.3);
   crossbar.rotation.z = Math.PI / 2;
   cockpitGroup.add(crossbar);
 
-  const cabinLightLeft = new THREE.PointLight(0x66ccff, 0.5, 4);
+  const cabinLightLeft = new THREE.PointLight(GLOW_COLOR, 0.6, 4);
   cabinLightLeft.position.set(-1.0, 0, 0);
   crossbar.add(cabinLightLeft);
 
-  const cabinLightRight = new THREE.PointLight(0x66ccff, 0.5, 4);
+  const cabinLightRight = new THREE.PointLight(GLOW_COLOR, 0.6, 4);
   cabinLightRight.position.set(1.0, 0, 0);
   crossbar.add(cabinLightRight);
 
@@ -114,6 +134,18 @@ export function createReworkedCockpit() {
   dashboard.position.set(0, 1.25, -0.8);
   dashboard.rotation.x = -0.4;
   cockpitGroup.add(dashboard);
+
+  const dashGlowMat = new THREE.MeshBasicMaterial({
+    color: GLOW_COLOR,
+    transparent: true,
+    opacity: 0.15,
+    blending: THREE.AdditiveBlending,
+    side: THREE.DoubleSide,
+  });
+  const dashGlow = new THREE.Mesh(new THREE.PlaneGeometry(3.0, 1.6), dashGlowMat);
+  dashGlow.position.set(0, 1.25, -0.81);
+  dashGlow.rotation.x = -0.4;
+  cockpitGroup.add(dashGlow);
 
   // --- Side Consoles ---
   // Low pedestals on either side of the seat for the throttle/joystick
@@ -132,25 +164,29 @@ export function createReworkedCockpit() {
   const throttleBase = new THREE.Mesh(new THREE.BoxGeometry(0.15, 0.05, 0.2), darkMetalMat);
   const throttleLever = new THREE.Mesh(
     new THREE.BoxGeometry(0.04, 0.3, 0.04),
-    new THREE.MeshStandardMaterial({ color: 0xffaa00, metalness: 0.8, roughness: 0.3, emissive: 0x331100 })
+    new THREE.MeshStandardMaterial({ color: ACCENT_COLOR, metalness: 0.9, roughness: 0.3, emissive: GLOW_COLOR })
   );
   throttleLever.position.y = 0.15;
   const throttlePivot = new THREE.Object3D();
   throttlePivot.add(throttleLever);
-  throttleGroup.add(throttleBase, throttlePivot);
+  const throttleRing = new THREE.Mesh(new THREE.TorusGeometry(0.1, 0.01, 8, 16), accentMat);
+  throttleRing.rotation.x = Math.PI / 2;
+  throttleGroup.add(throttleBase, throttleRing, throttlePivot);
   throttleGroup.name = 'Throttle';
   leftConsole.add(throttleGroup);
   throttleGroup.position.set(0, 0.05, 0.05);
 
   const joystickGroup = new THREE.Group();
   const stickBase = new THREE.Mesh(new THREE.CylinderGeometry(0.12, 0.14, 0.04, 32), darkMetalMat);
-  const stick = new THREE.Mesh(new THREE.CylinderGeometry(0.03, 0.02, 0.25, 16), new THREE.MeshStandardMaterial({ color: 0x00aaff, metalness: 0.8, roughness: 0.4 }));
+  const stick = new THREE.Mesh(new THREE.CylinderGeometry(0.03, 0.02, 0.25, 16), new THREE.MeshStandardMaterial({ color: ACCENT_COLOR, metalness: 0.8, roughness: 0.4 }));
   stick.position.y = 0.125;
-  const stickTop = new THREE.Mesh(new THREE.SphereGeometry(0.05, 16, 16), new THREE.MeshStandardMaterial({ color: 0x0066cc, metalness: 0.6, roughness: 0.3, emissive: 0x001133 }));
+  const stickTop = new THREE.Mesh(new THREE.SphereGeometry(0.05, 16, 16), new THREE.MeshStandardMaterial({ color: ACCENT_COLOR, metalness: 0.6, roughness: 0.3, emissive: GLOW_COLOR }));
   stickTop.position.y = 0.25;
   const joystickPivot = new THREE.Object3D();
   joystickPivot.add(stick, stickTop);
-  joystickGroup.add(stickBase, joystickPivot);
+  const joystickRing = new THREE.Mesh(new THREE.TorusGeometry(0.1, 0.01, 8, 16), accentMat);
+  joystickRing.rotation.x = Math.PI / 2;
+  joystickGroup.add(stickBase, joystickRing, joystickPivot);
   joystickGroup.name = 'Joystick';
   rightConsole.add(joystickGroup);
   joystickGroup.position.set(0, 0.05, 0.05);
@@ -164,8 +200,7 @@ export function createReworkedCockpit() {
 
   // --- Probe Cannon ---
   const cannonGeom = new THREE.CylinderGeometry(0.1, 0.08, 2.0, 16);
-  const cannonMat = new THREE.MeshStandardMaterial({ color: 0xbbbbff, metalness: 0.9, roughness: 0.2 });
-  const cannon = new THREE.Mesh(cannonGeom, cannonMat);
+  const cannon = new THREE.Mesh(cannonGeom, accentMat);
   cannon.position.set(0, -0.2, -2.7);
   cannon.rotation.x = Math.PI / 2;
   cockpitGroup.add(cannon);

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -2,7 +2,7 @@
  * main.js (Refactored & Corrected)
  *
  * Entry point for the VR solar system experience. This version introduces:
- * - Creates a cockpit via createCockpit with the redesigned layout.
+ * - Creates a cockpit via createCockpit with a sleeker neon-themed layout.
  * - Integration with the single-panel UI system.
  * - Slightly boosted lighting to complement the glowing dashboard.
  * - A critical fix in the animation loop to prevent an endless loading screen.


### PR DESCRIPTION
## Summary
- apply a blue neon theme to the cockpit materials and lighting
- add subtle glow elements around the dashboard and floor
- adjust overlay colors in `index.html`
- mention the new look in `main.js`

## Testing
- `node -c scripts/cockpit.js`
- `node -c scripts/main.js`

------
https://chatgpt.com/codex/tasks/task_e_687f98550f4c8331a5e2f7c246c060b6