### PR TITLE
Refactor cockpit UI into multi‑panel command center

### DIFF
--- a/scripts/cockpit.js
+++ b/scripts/cockpit.js
@@ -2,10 +2,11 @@
  * cockpit.js
  *
  * Implements a compact standing console instead of the original seated
- * cockpit.  The new layout resembles a high-tech lectern: a single table with
- * an angled screen and the joystick, throttle and fire button mounted on top.
- * The intent is for players to stand at the console and control everything
- * without moving around the room.
+ * cockpit.  The previous revision used a single large dashboard panel which
+ * looked somewhat like a blank "black hole".  This update splits the dashboard
+ * into three smaller screens arranged in a command-centre style layout.  It
+ * better resembles the multi-panel look of a sci‑fi bridge while keeping the
+ * lectern form factor so players can stand comfortably at the console.
  */
 
 import * as THREE from 'three';
@@ -13,7 +14,7 @@ import * as THREE from 'three';
 /**
  * Creates the lectern-style cockpit.
  *
- * @returns {object} References to the cockpit group, dashboard and controls.
+ * @returns {object} References to the cockpit group, panels and controls.
  */
 export function createLecternCockpit() {
   const cockpitGroup = new THREE.Group();
@@ -60,31 +61,48 @@ export function createLecternCockpit() {
   tableTop.rotation.x = -0.15;
   cockpitGroup.add(tableTop);
 
-  // Dashboard panel
-  const dashboardGeom = new THREE.PlaneGeometry(1.4, 0.8);
-  const dashboardMat = new THREE.MeshBasicMaterial({
-    color: 0x000000,
-    side: THREE.DoubleSide,
-  });
-  const dashboard = new THREE.Mesh(dashboardGeom, dashboardMat);
-  dashboard.name = 'DashboardPanel';
-  dashboard.position.set(0, 1.5, -0.3);
-  dashboard.rotation.x = -0.3;
-  cockpitGroup.add(dashboard);
+  // --- Dashboard Panels -------------------------------------------------
+  // Instead of one large dashboard there are now two side panels and a
+  // central screen for the orrery.  The panels use basic black materials and a
+  // subtle glow so the UI textures can be swapped in by the main application.
 
-  const dashGlow = new THREE.Mesh(
-    new THREE.PlaneGeometry(1.5, 0.9),
-    new THREE.MeshBasicMaterial({
-      color: GLOW_COLOR,
-      transparent: true,
-      opacity: 0.15,
-      blending: THREE.AdditiveBlending,
-      side: THREE.DoubleSide,
-    })
-  );
-  dashGlow.position.set(0, 1.5, -0.31);
-  dashGlow.rotation.x = -0.3;
-  cockpitGroup.add(dashGlow);
+  const panelGeom = new THREE.PlaneGeometry(0.7, 0.8);
+  const createPanel = (name, x) => {
+    const mat = new THREE.MeshBasicMaterial({ color: 0x000000, side: THREE.DoubleSide });
+    const mesh = new THREE.Mesh(panelGeom, mat);
+    mesh.name = name;
+    mesh.position.set(x, 1.5, -0.3);
+    mesh.rotation.x = -0.3;
+    cockpitGroup.add(mesh);
+
+    const glow = new THREE.Mesh(
+      new THREE.PlaneGeometry(0.75, 0.85),
+      new THREE.MeshBasicMaterial({
+        color: GLOW_COLOR,
+        transparent: true,
+        opacity: 0.15,
+        blending: THREE.AdditiveBlending,
+        side: THREE.DoubleSide,
+      })
+    );
+    glow.position.set(x, 1.5, -0.31);
+    glow.rotation.x = -0.3;
+    cockpitGroup.add(glow);
+
+    return mesh;
+  };
+
+  const leftPanel = createPanel('LeftPanel', -0.8);
+  const rightPanel = createPanel('RightPanel', 0.8);
+
+  // Central orrery screen
+  const orreryGeom = new THREE.PlaneGeometry(0.6, 0.6);
+  const orreryMat = new THREE.MeshBasicMaterial({ color: 0x000000, side: THREE.DoubleSide });
+  const orreryMount = new THREE.Mesh(orreryGeom, orreryMat);
+  orreryMount.name = 'OrreryScreen';
+  orreryMount.position.set(0, 1.5, -0.32);
+  orreryMount.rotation.x = -0.3;
+  cockpitGroup.add(orreryMount);
 
   // Throttle control
   const throttleGroup = new THREE.Group();
@@ -173,7 +191,9 @@ export function createLecternCockpit() {
 
   return {
     group: cockpitGroup,
-    dashboard,
+    leftPanel,
+    rightPanel,
+    orreryMount,
     throttle: throttleGroup,
     joystick: joystickGroup,
     throttlePivot,

--- a/scripts/controls.js
+++ b/scripts/controls.js
@@ -264,9 +264,14 @@ export function setupControls(renderer, scene, cockpit, ui, fireProbe, orrery) {
         data.isSelecting = false;
         return;
       }
-      // Otherwise test against the dashboard for UI interactions.
-      const dashboardBox = new THREE.Box3().setFromObject(cockpit.dashboard);
-      if (dashboardBox.containsPoint(tipPos)) {
+      // Otherwise test against the dashboard panels for UI interactions.
+      const panels = [
+        { mesh: cockpit.leftPanel, name: 'left' },
+        { mesh: cockpit.rightPanel, name: 'right' }
+      ];
+      for (const panel of panels) {
+        const box = new THREE.Box3().setFromObject(panel.mesh);
+        if (!box.containsPoint(tipPos)) continue;
         const tempRay = new THREE.Raycaster();
         const handPos = new THREE.Vector3();
         data.hand.getWorldPosition(handPos);
@@ -284,11 +289,12 @@ export function setupControls(renderer, scene, cockpit, ui, fireProbe, orrery) {
           }
         }
 
-        // Otherwise fall back to the 2D dashboard UI
-        const dashboardIntersects = tempRay.intersectObject(cockpit.dashboard);
-        if (dashboardIntersects.length > 0) {
-          ui.handlePointer(dashboardIntersects[0].uv);
+        // Otherwise fall back to the 2D dashboard UI for that panel
+        const hits = tempRay.intersectObject(panel.mesh);
+        if (hits.length > 0) {
+          ui.handlePointer(panel.name, hits[0].uv);
           data.isSelecting = false;
+          break;
         }
       }
     }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -117,9 +117,9 @@ async function init() {
   const cockpit = createCockpit();
   scene.add(cockpit.group);
 
-  // Miniature orrery displayed on the dashboard
+  // Miniature orrery displayed on the centre screen
   const orrery = createOrrery(renderer);
-  cockpit.group.add(orrery.mesh);
+  cockpit.orreryMount.add(orrery.mesh);
 
   // Add a point light to illuminate the controls.
   const controlLight = new THREE.PointLight(0xaabbee, 0.8, 5);
@@ -127,11 +127,12 @@ async function init() {
   cockpit.group.add(controlLight);
 
   // === Audio System ===
-  const audio = await initAudio(camera, cockpit.dashboard);
+  const audio = await initAudio(camera, cockpit.orreryMount);
 
   // === UI System ===
   const ui = createUI(
-    cockpit.dashboard,
+    cockpit.leftPanel,
+    cockpit.rightPanel,
     (bodyIndex) => { // onWarpSelect
       warpToBody(bodyIndex);
       if (audio) audio.playWarp();

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -1,259 +1,243 @@
 /*
- * ui.js (Refactored for Single Dashboard)
+ * ui.js (Command Centre Panels)
  *
- * This module builds and updates the UI on a single, large dashboard panel.
- * - Draws all UI components (warp, map, info, controls) onto one canvas.
- * - NEW: Uses the provided 'ui.png' nebula texture as a background.
- * - NEW: The material for the dashboard panel uses Additive Blending, making
- * the UI text and elements glow for a high-tech, readable look.
+ * Provides the cockpit user interface using two separate dashboard panels. The
+ * left panel shows navigation controls and planetary information while the right
+ * panel exposes ship systems. Each panel is drawn on its own canvas with a
+ * nebula background and additive blending to create a glowing Star Trek style.
  */
 
 import * as THREE from 'three';
 import { solarBodies } from './data.js';
 import { C_KMPS, MPH_TO_KMPS } from './constants.js';
 
-// Pre-load the nebula background image for the UI panels.
 const bgImage = new Image();
 bgImage.src = './textures/ui.png';
 
-export function createUI(dashboardPanel, onWarpSelect, onSpeedChange, onLaunchProbe, onToggleAutopilot, onToggleLabels, onFunFact) {
-  // NEW: Using a larger canvas for the single dashboard layout
-  const canvasSize = { width: 1024, height: 512 };
-  const canvas = document.createElement('canvas');
-  canvas.width = canvasSize.width;
-  canvas.height = canvasSize.height;
-  const context = canvas.getContext('2d');
+export function createUI(leftPanel, rightPanel, onWarpSelect, onSpeedChange, onLaunchProbe, onToggleAutopilot, onToggleLabels, onFunFact) {
+  const size = { width: 512, height: 512 };
 
-  const texture = new THREE.CanvasTexture(canvas);
-  texture.encoding = THREE.sRGBEncoding;
-  texture.anisotropy = 4;
-  
-  // NEW: Make the UI glow by using Additive Blending.
-  // The black parts of the canvas will be transparent, and bright
-  // parts will "add" light to the scene.
-  dashboardPanel.material = new THREE.MeshBasicMaterial({
-      map: texture,
-      transparent: true,
-      blending: THREE.AdditiveBlending,
-      side: THREE.DoubleSide
+  function makeCanvas() {
+    const c = document.createElement('canvas');
+    c.width = size.width;
+    c.height = size.height;
+    return c;
+  }
+
+  const leftCanvas = makeCanvas();
+  const leftCtx = leftCanvas.getContext('2d');
+  const leftTex = new THREE.CanvasTexture(leftCanvas);
+  leftTex.encoding = THREE.sRGBEncoding;
+  leftTex.anisotropy = 4;
+  leftPanel.material = new THREE.MeshBasicMaterial({
+    map: leftTex,
+    transparent: true,
+    blending: THREE.AdditiveBlending,
+    side: THREE.DoubleSide,
   });
 
-  // --- UI State ---
-  let state = {
-    warpTargetIndex: 2, // Default: Earth
-    infoBodyIndex: 2,   // Body to show info for
+  const rightCanvas = makeCanvas();
+  const rightCtx = rightCanvas.getContext('2d');
+  const rightTex = new THREE.CanvasTexture(rightCanvas);
+  rightTex.encoding = THREE.sRGBEncoding;
+  rightTex.anisotropy = 4;
+  rightPanel.material = new THREE.MeshBasicMaterial({
+    map: rightTex,
+    transparent: true,
+    blending: THREE.AdditiveBlending,
+    side: THREE.DoubleSide,
+  });
+
+  const state = {
+    warpTargetIndex: 2,
+    infoBodyIndex: 2,
     funFactIndex: 0,
-    speedFraction: 0.1, // Ship travel speed
-    timeScale: 1.0,     // Simulation speed
-    probeMassFraction: 0.1, // 0-1 fraction for mass slider
-    probeSpeedFraction: 0.1, // 0-1 fraction for speed slider
+    speedFraction: 0.1,
+    timeScale: 1.0,
+    probeMassFraction: 0.1,
+    probeSpeedFraction: 0.1,
     autopilot: false,
     labels: true,
     needsRedraw: true,
   };
 
-  // If the background image loads after initialization, trigger a redraw so it
-  // becomes visible.
   bgImage.addEventListener('load', () => { state.needsRedraw = true; });
 
-  const warpTargets = solarBodies.map((b, idx) => ({ name: b.name, index: idx }));
+  const warpTargets = solarBodies.map((b, i) => ({ name: b.name, index: i }));
 
-  // --- Drawing Helpers ---
-  function drawBackground() {
-    // Fill with black first to ensure glow effect works correctly
-    context.fillStyle = '#000000';
-    context.fillRect(0, 0, canvasSize.width, canvasSize.height);
-    // Draw the nebula image with some transparency
+  function drawBg(ctx) {
+    ctx.fillStyle = '#000000';
+    ctx.fillRect(0, 0, size.width, size.height);
     if (bgImage.complete && bgImage.naturalWidth > 0) {
-      context.globalAlpha = 0.3; // Make the nebula subtle
-      context.drawImage(bgImage, 0, 0, canvasSize.width, canvasSize.height);
-      context.globalAlpha = 1.0; // Reset alpha
+      ctx.globalAlpha = 0.3;
+      ctx.drawImage(bgImage, 0, 0, size.width, size.height);
+      ctx.globalAlpha = 1.0;
     }
   }
-  
-  function drawText(text, x, y, size = 18, color = '#aaddff', weight = 'normal') {
-    context.font = `${weight} ${size}px Orbitron`;
-    context.fillStyle = color;
-    context.fillText(text, x, y);
+
+  function text(ctx, str, x, y, s = 18, col = '#aaddff', weight = 'normal') {
+    ctx.font = `${weight} ${s}px Orbitron`;
+    ctx.fillStyle = col;
+    ctx.fillText(str, x, y);
   }
 
-  // --- Main Drawing Function ---
-  function drawDashboard(bodyPositions) {
-    drawBackground();
-
-    // --- Column 1: Navigation (Left) ---
-    const col1X = 30;
-    drawText('WARP TARGET', col1X, 40, 22, '#ffffff', 'bold');
-    warpTargets.forEach((target, i) => {
+  function drawLeft(bodyPositions) {
+    drawBg(leftCtx);
+    const x0 = 30;
+    text(leftCtx, 'WARP TARGET', x0, 40, 22, '#ffffff', 'bold');
+    warpTargets.forEach((t, i) => {
       const y = 80 + i * 24;
       if (i === state.warpTargetIndex) {
-        context.fillStyle = 'rgba(100, 150, 255, 0.5)';
-        context.fillRect(col1X - 10, y - 18, 200, 24);
+        leftCtx.fillStyle = 'rgba(100,150,255,0.5)';
+        leftCtx.fillRect(x0 - 10, y - 18, 200, 24);
       }
-      drawText(target.name, col1X, y, 16, i === state.warpTargetIndex ? '#ffffff' : '#bbddff');
+      text(leftCtx, t.name, x0, y, 16, i === state.warpTargetIndex ? '#ffffff' : '#bbddff');
     });
 
-    // --- Column 2: Map and Info (Center) ---
-    const col2X = 280;
-    drawText('SYSTEM STATUS', col2X, 40, 22, '#ffffff', 'bold');
     const body = solarBodies[state.infoBodyIndex] || solarBodies[0];
-    drawText(body.name.toUpperCase(), col2X, 70, 20, '#ffffaa');
-    
-    // The 2D map was replaced by a 3D orrery rendered separately.
-
-    // Info Text
     const fact = body.funFacts ? body.funFacts[state.funFactIndex % body.funFacts.length] : 'No data.';
-    context.fillStyle = '#cccccc';
-    context.font = '14px Orbitron';
-    // word wrap
-    let line = '', y = 360, textX = col2X;
+    leftCtx.fillStyle = '#cccccc';
+    leftCtx.font = '14px Orbitron';
+    let line = '', y = 300;
     const words = fact.split(' ');
-    for (const word of words) {
-        const testLine = line + word + ' ';
-        if (context.measureText(testLine).width > 420 && line.length > 0) {
-            context.fillText(line, textX, y);
-            line = word + ' ';
-            y += 20;
-        } else {
-            line = testLine;
-        }
+    for (const w of words) {
+      const test = line + w + ' ';
+      if (leftCtx.measureText(test).width > 440 && line) {
+        leftCtx.fillText(line, x0, y);
+        line = w + ' ';
+        y += 20;
+      } else {
+        line = test;
+      }
     }
-    context.fillText(line, textX, y);
-    drawText('Touch info panel to cycle facts', textX, canvasSize.height - 20, 12, '#888888');
+    leftCtx.fillText(line, x0, y);
+    text(leftCtx, 'Touch to cycle facts', x0, size.height - 20, 12, '#888888');
+    leftTex.needsUpdate = true;
+  }
 
-    // --- Column 3: Ship Systems (Right) ---
-    const col3X = 720;
-    drawText('SYSTEMS CONTROL', col3X, 40, 22, '#ffffff', 'bold');
+  function drawRight() {
+    drawBg(rightCtx);
+    const x0 = 40;
+    text(rightCtx, 'SYSTEMS', x0, 40, 22, '#ffffff', 'bold');
+    const w = 280;
+    text(rightCtx, `SHIP SPEED: ${speedToStr(state.speedFraction)}`, x0, 90, 16);
+    rightCtx.fillStyle = '#333344';
+    rightCtx.fillRect(x0, 110, w, 8);
+    rightCtx.fillStyle = '#ffaa00';
+    rightCtx.fillRect(x0, 110, w * state.speedFraction, 8);
 
-    const sliderWidth = 280;
-    // Ship Speed
-    drawText(`SHIP SPEED: ${speedFractionToString(state.speedFraction)}`, col3X, 90, 16);
-    context.fillStyle = '#333344';
-    context.fillRect(col3X, 110, sliderWidth, 8);
-    context.fillStyle = '#ffaa00';
-    context.fillRect(col3X, 110, sliderWidth * state.speedFraction, 8);
-    
-    // Time Scale
-    drawText(`TIME WARP: ${state.timeScale.toFixed(1)}x`, col3X, 150, 16);
-    context.fillStyle = '#333344';
-    context.fillRect(col3X, 170, sliderWidth, 8);
-    context.fillStyle = '#aaccff';
-    context.fillRect(col3X, 170, sliderWidth * ((state.timeScale - 0.1) / 49.9), 8);
+    text(rightCtx, `TIME WARP: ${state.timeScale.toFixed(1)}x`, x0, 150, 16);
+    rightCtx.fillStyle = '#333344';
+    rightCtx.fillRect(x0, 170, w, 8);
+    rightCtx.fillStyle = '#aaccff';
+    rightCtx.fillRect(x0, 170, w * ((state.timeScale - 0.1) / 49.9), 8);
 
-    // Probe Mass & Speed
     const probeMass = 10 + Math.pow(state.probeMassFraction, 3) * 1e6;
-    drawText(`PROBE MASS: ${probeMass.toFixed(0)} kg`, col3X, 210, 16);
-    context.fillStyle = '#333344';
-    context.fillRect(col3X, 230, sliderWidth, 8);
-    context.fillStyle = '#ff8888';
-    context.fillRect(col3X, 230, sliderWidth * state.probeMassFraction, 8);
+    text(rightCtx, `PROBE MASS: ${probeMass.toFixed(0)} kg`, x0, 210, 16);
+    rightCtx.fillStyle = '#333344';
+    rightCtx.fillRect(x0, 230, w, 8);
+    rightCtx.fillStyle = '#ff8888';
+    rightCtx.fillRect(x0, 230, w * state.probeMassFraction, 8);
 
     const probeSpeed = state.probeSpeedFraction * 100;
-    drawText(`LAUNCH VELOCITY: ${probeSpeed.toFixed(1)}% c`, col3X, 270, 16);
-    context.fillStyle = '#333344';
-    context.fillRect(col3X, 290, sliderWidth, 8);
-    context.fillStyle = '#ff8888';
-    context.fillRect(col3X, 290, sliderWidth * state.probeSpeedFraction, 8);
+    text(rightCtx, `LAUNCH VELOCITY: ${probeSpeed.toFixed(1)}% c`, x0, 270, 16);
+    rightCtx.fillStyle = '#333344';
+    rightCtx.fillRect(x0, 290, w, 8);
+    rightCtx.fillStyle = '#ff8888';
+    rightCtx.fillRect(x0, 290, w * state.probeSpeedFraction, 8);
 
-    // Autopilot Toggle
-    drawText('AUTOPILOT', col3X, 330, 16);
-    context.fillStyle = state.autopilot ? '#226622' : '#662222';
-    context.fillRect(col3X, 350, 120, 24);
-    drawText(state.autopilot ? 'ON' : 'OFF', col3X + 10, 368, 16, '#ffffff');
+    text(rightCtx, 'AUTOPILOT', x0, 330, 16);
+    rightCtx.fillStyle = state.autopilot ? '#226622' : '#662222';
+    rightCtx.fillRect(x0, 350, 120, 24);
+    text(rightCtx, state.autopilot ? 'ON' : 'OFF', x0 + 10, 368, 16, '#ffffff');
 
-    // Labels Toggle
-    drawText('LABELS', col3X, 390, 16);
-    context.fillStyle = state.labels ? '#226622' : '#662222';
-    context.fillRect(col3X, 410, 120, 24);
-    drawText(state.labels ? 'ON' : 'OFF', col3X + 10, 428, 16, '#ffffff');
+    text(rightCtx, 'LABELS', x0, 390, 16);
+    rightCtx.fillStyle = state.labels ? '#226622' : '#662222';
+    rightCtx.fillRect(x0, 410, 120, 24);
+    text(rightCtx, state.labels ? 'ON' : 'OFF', x0 + 10, 428, 16, '#ffffff');
 
-    texture.needsUpdate = true;
-    state.needsRedraw = false;
+    rightTex.needsUpdate = true;
   }
 
-  function speedFractionToString(f) {
-      if (f === 0) return "STOPPED";
-      const minMph = 1;
-      const c_in_mph = C_KMPS / MPH_TO_KMPS;
-      const logMin = Math.log(minMph);
-      const logMax = Math.log(c_in_mph);
-      const mph = Math.exp(logMin + f * (logMax - logMin));
-      if (mph < 1000) return `${mph.toFixed(0)} mph`;
-      if (mph < 1e6) return `${(mph/1000).toFixed(1)}k mph`;
-      const fractionOfC = mph / c_in_mph;
-      return `${fractionOfC.toFixed(4)} c`;
+  function speedToStr(f) {
+    if (f === 0) return 'STOPPED';
+    const minMph = 1;
+    const cMph = C_KMPS / MPH_TO_KMPS;
+    const logMin = Math.log(minMph);
+    const logMax = Math.log(cMph);
+    const mph = Math.exp(logMin + f * (logMax - logMin));
+    if (mph < 1000) return `${mph.toFixed(0)} mph`;
+    if (mph < 1e6) return `${(mph / 1000).toFixed(1)}k mph`;
+    const fracC = mph / cMph;
+    return `${fracC.toFixed(4)} c`;
   }
 
-  function update(bodyPositions, closestBodyIndex) {
-    if (closestBodyIndex !== -1 && state.infoBodyIndex !== closestBodyIndex) {
-      state.infoBodyIndex = closestBodyIndex;
+  function update(bodyPositions, closestIndex) {
+    if (closestIndex !== -1 && state.infoBodyIndex !== closestIndex) {
+      state.infoBodyIndex = closestIndex;
       state.funFactIndex = 0;
       state.needsRedraw = true;
     }
-    if(state.needsRedraw) {
-        drawDashboard(bodyPositions);
+    if (state.needsRedraw) {
+      drawLeft(bodyPositions);
+      drawRight();
+      state.needsRedraw = false;
     }
   }
 
-  function handlePointer(uv) {
+  function handlePointer(panel, uv) {
     state.needsRedraw = true;
-    const x = uv.u * canvasSize.width;
-    const y = (1 - uv.v) * canvasSize.height;
+    const x = uv.u * size.width;
+    const y = (1 - uv.v) * size.height;
 
-    // Column 1: Warp List
-    if (x > 20 && x < 230) {
-      const lineHeight = 24;
-      const idx = Math.floor((y - 80 + lineHeight / 2) / lineHeight);
-      if (idx >= 0 && idx < warpTargets.length) {
-        state.warpTargetIndex = idx;
-        state.funFactIndex = 0;
-        onWarpSelect(idx);
-      }
-    } 
-    // Column 2: Info
-    else if (x > 280 && x < 700) {
+    if (panel === 'left') {
+      if (x > 20 && x < 230) {
+        const lineHeight = 24;
+        const idx = Math.floor((y - 80 + lineHeight / 2) / lineHeight);
+        if (idx >= 0 && idx < warpTargets.length) {
+          state.warpTargetIndex = idx;
+          state.funFactIndex = 0;
+          onWarpSelect && onWarpSelect(idx);
+        }
+      } else {
         state.funFactIndex++;
         if (onFunFact) {
           const body = solarBodies[state.infoBodyIndex] || solarBodies[0];
           const facts = body.funFacts || [];
-          if (facts.length > 0) {
-            const fact = facts[state.funFactIndex % facts.length];
-            onFunFact(fact);
+          if (facts.length) {
+            onFunFact(facts[state.funFactIndex % facts.length]);
           }
         }
-    }
-    // Column 3: Sliders
-    else if (x > 720 && x < 1000) {
-        const sliderX = 720;
-        const sliderW = 280;
-        const fraction = THREE.MathUtils.clamp((x - sliderX) / sliderW, 0, 1);
-        if (y > 100 && y < 140) state.speedFraction = fraction;
-        else if (y > 160 && y < 200) state.timeScale = 0.1 + fraction * 49.9;
-        else if (y > 220 && y < 260) state.probeMassFraction = fraction;
-        else if (y > 280 && y < 320) state.probeSpeedFraction = fraction;
-        else if (y > 340 && y < 374) {
-            state.autopilot = !state.autopilot;
-            if (onToggleAutopilot) onToggleAutopilot(state.autopilot);
-        }
-        else if (y > 400 && y < 434) {
-            state.labels = !state.labels;
-            if (onToggleLabels) onToggleLabels(state.labels);
-        }
+      }
+    } else if (panel === 'right') {
+      const sliderX = 40;
+      const sliderW = 280;
+      const f = THREE.MathUtils.clamp((x - sliderX) / sliderW, 0, 1);
+      if (y > 100 && y < 140) state.speedFraction = f;
+      else if (y > 160 && y < 200) state.timeScale = 0.1 + f * 49.9;
+      else if (y > 220 && y < 260) state.probeMassFraction = f;
+      else if (y > 280 && y < 320) state.probeSpeedFraction = f;
+      else if (y > 340 && y < 374) {
+        state.autopilot = !state.autopilot;
+        onToggleAutopilot && onToggleAutopilot(state.autopilot);
+      } else if (y > 400 && y < 434) {
+        state.labels = !state.labels;
+        onToggleLabels && onToggleLabels(state.labels);
+      }
     }
   }
 
-  // Initial Draw
   update(solarBodies.map(() => new THREE.Vector3()), state.infoBodyIndex);
 
   return {
     update,
     handlePointer,
-    selectWarpTarget(index) {
-      if (index >= 0 && index < warpTargets.length) {
-        state.warpTargetIndex = index;
-        state.infoBodyIndex = index;
+    selectWarpTarget(i) {
+      if (i >= 0 && i < warpTargets.length) {
+        state.warpTargetIndex = i;
+        state.infoBodyIndex = i;
         state.funFactIndex = 0;
-        if (onWarpSelect) onWarpSelect(index);
+        onWarpSelect && onWarpSelect(i);
         state.needsRedraw = true;
       }
     },
@@ -264,6 +248,6 @@ export function createUI(dashboardPanel, onWarpSelect, onSpeedChange, onLaunchPr
     get probeLaunchSpeed() { return state.probeSpeedFraction * C_KMPS; },
     get autopilot() { return state.autopilot; },
     get warpTargetIndex() { return state.warpTargetIndex; },
-    get labelsVisible() { return state.labels; }
+    get labelsVisible() { return state.labels; },
   };
 }


### PR DESCRIPTION
## Summary
- split cockpit dashboard into left/right panels and a central orrery screen
- update main flow to attach UI canvases to new panels
- redesign UI module for two-panel layout
- handle controller interactions with either panel

## Testing
- `node --check scripts/main.js`
- `node --check scripts/cockpit.js`
- `node --check scripts/controls.js`
- `node --check scripts/ui.js`


------
https://chatgpt.com/codex/tasks/task_e_687fb99475cc8331a450ed15ef889106