### PR TITLE
Fix missing VR entry by restoring WebXR button

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,14 +31,6 @@
       font-family: 'Orbitron', sans-serif;
     }
 
-    /* VR entry button positioning */
-    #VRButton {
-      position: absolute !important;
-      left: 50% !important;
-      transform: translateX(-50%) !important;
-      bottom: 20px !important;
-      z-index: 100;
-    }
 
     /* Overlay for XR status messages.  Hidden by default so it does not
        obstruct the user's view once the app is running in VR.  The
@@ -73,8 +65,6 @@
     <span id="xr-message">Initialising WebXR…</span><br>
     <small>Tap panels with your index finger to interact. Close your hand to grab controls.</small>
   </div>
-  <!-- Button to manually start an immersive VR session -->
-  <button id="VRButton">Enter VR</button>
   <!-- Main application script -->
   <script type="module" src="./scripts/main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- remove unused VRButton HTML element and style
- add Three.js VRButton utility
- show XR availability status in overlay
- keep overlay hidden when in VR session

## Testing
- `node -e "import('./scripts/main.js').then(()=>console.log('OK')).catch(e=>console.error(e))" --experimental-modules` *(fails: Cannot find package 'three')*

------
https://chatgpt.com/codex/tasks/task_e_6881785a14f083318307efb6e0106246