### PR TITLE
Fix cockpit property and add grab helpers

### DIFF
--- a/scripts/cockpit.js
+++ b/scripts/cockpit.js
@@ -177,6 +177,46 @@ export function createDashboardCockpit() {
   cannon.rotation.x = Math.PI / 2;
   cockpitGroup.add(cannon);
 
+  // --- Grabbing helpers ---
+  // Track which hand is currently grabbing each control so that the
+  // fingertip position can drive the lever/joystick animations.
+  const grabbingThrottle = [false, false];
+  const grabbingJoystick = [false, false];
+
+  function startGrabbingThrottle(handIndex) {
+    grabbingThrottle[handIndex] = true;
+  }
+
+  function stopGrabbingThrottle(handIndex) {
+    grabbingThrottle[handIndex] = false;
+  }
+
+  function startGrabbingJoystick(handIndex) {
+    grabbingJoystick[handIndex] = true;
+  }
+
+  function stopGrabbingJoystick(handIndex) {
+    grabbingJoystick[handIndex] = false;
+  }
+
+  // Update the throttle/joystick orientation based on the fingertip position
+  // of the controlling hand.
+  function updateGrab(handIndex, tipPosWorld) {
+    if (grabbingThrottle[handIndex]) {
+      const local = throttleGroup.worldToLocal(tipPosWorld.clone());
+      const y = THREE.MathUtils.clamp(local.y, 0, 0.3);
+      const angle = THREE.MathUtils.mapLinear(y, 0, 0.3, 0, Math.PI / 2);
+      throttlePivot.rotation.x = -angle;
+    }
+    if (grabbingJoystick[handIndex]) {
+      const local = joystickGroup.worldToLocal(tipPosWorld.clone());
+      const maxAngle = Math.PI / 4;
+      const xAngle = THREE.MathUtils.clamp(local.x * 2, -maxAngle, maxAngle);
+      const yAngle = THREE.MathUtils.clamp(-local.z * 2, -maxAngle, maxAngle);
+      joystickPivot.rotation.set(yAngle, 0, xAngle);
+    }
+  }
+
   return {
     group: cockpitGroup,
     dashboard: dashboard,
@@ -186,6 +226,11 @@ export function createDashboardCockpit() {
     joystickPivot,
     fireButton,
     cannon,
+    startGrabbingThrottle,
+    stopGrabbingThrottle,
+    startGrabbingJoystick,
+    stopGrabbingJoystick,
+    updateGrab,
   };
 }
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -78,17 +78,20 @@ async function main() {
   // comfortably in front of the player rather than below their feet. A slight
   // downward offset (negative Y) makes the desk feel like it's at waist height.
   const cockpit = createCockpit();
-  cockpit.root.position.set(0, -0.4, -1.5);
-  scene.add(cockpit.root);
+  // createCockpit returns an object with a `group` that acts as the root of
+  // the cockpit hierarchy. Older code referenced `cockpit.root`, so adapt all
+  // usages to the new `group` property.
+  cockpit.group.position.set(0, -0.4, -1.5);
+  scene.add(cockpit.group);
 
   // Initialize audio system
-  const audio = await initAudio(camera, cockpit.root);
+  const audio = await initAudio(camera, cockpit.group);
 
   // Create the orrery and attach it to the cockpit. We raise the miniature
   // solar system so that it rests on the desk surface and is easy to see.
   const orrery = createOrrery(bodies);
   orrery.group.position.set(0, 0.1, 0.5);
-  cockpit.root.add(orrery.group);
+  cockpit.group.add(orrery.group);
 
   // Create the UI panels and attach them to the cockpit.
   const ui = createUI(bodies, {
@@ -102,15 +105,15 @@ async function main() {
   ui.rightMesh.position.set(0.9, 0.3, 0.4);
   // The bottom panel sits toward the front edge of the desk
   ui.bottomMesh.position.set(0, -0.3, 0.7);
-  cockpit.root.add(ui.leftMesh);
-  cockpit.root.add(ui.rightMesh);
-  cockpit.root.add(ui.bottomMesh);
+  cockpit.group.add(ui.leftMesh);
+  cockpit.group.add(ui.rightMesh);
+  cockpit.group.add(ui.bottomMesh);
 
   // Create hand controls. When the fire callback is invoked, it launches a
   // probe from the muzzle position on the cockpit and plays a beep.
   const controls = createControls(renderer, scene, camera, cockpit, ui, () => {
     const muzzle = new THREE.Vector3(0, -0.3, 0.6);
-    cockpit.root.localToWorld(muzzle);
+    cockpit.group.localToWorld(muzzle);
     const solarOrigin = solarGroup.getWorldPosition(new THREE.Vector3());
     const launchPos = muzzle.clone().sub(solarOrigin);
     const forward = new THREE.Vector3(0, 0, -1);


### PR DESCRIPTION
## Summary
- update main.js to use `cockpit.group`
- expose grab helper methods from cockpit
- implement simple throttle/joystick grabbing logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68818878fae483319f4ec6f6c9892c7c