### PR TITLE
Restore VR entry by fixing cockpit import

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -7,7 +7,13 @@
 import * as THREE from 'three';
 import { createSolarSystem, updateSolarSystem } from './solarSystem.js';
 import { VRButton } from 'three/examples/jsm/webxr/VRButton.js';
-import { createCockpit } from './lecternCockpit.js';
+// The cockpit implementation already exports `createCockpit` from
+// `cockpit.js`.  A previous refactor accidentally changed the import to
+// `lecternCockpit.js`, but that file does not exist which causes the entire
+// application script to fail and the VR button never appears.  Revert to
+// importing from the correct module so the page can load and WebXR entry works
+// again.
+import { createCockpit } from './cockpit.js';
 import { createUI } from './ui.js';
 import { createControls } from './controls.js';
 import { createOrrery, updateOrrery } from './orrery.js';


### PR DESCRIPTION
## Summary
- fix import path for cockpit module so `main.js` loads correctly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688194d4c1fc8331a58cd4517e4156b8