### PR TITLE
Add finger-driven flight controls

### DIFF
--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -26,3 +26,8 @@ export const C_KMPS = 299_792.458;
 // Conversion from miles per hour to kilometres per second.  The throttle slider
 // uses an exponential mapping between 1 mph and c.
 export const MPH_TO_KMPS = 1.60934 / 3600;
+
+// Maximum player flight speed in world units per second.  This value is
+// intentionally modest so that manual flight feels slow compared to the warp
+// jumps triggered from the UI.
+export const MAX_FLIGHT_SPEED = 0.5;

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -160,7 +160,8 @@ async function main() {
     const cameraPos = new THREE.Vector3();
     camera.getWorldPosition(cameraPos);
     updateOrrery(orrery, solarGroup, cameraPos);
-    controls.update(deltaSec);
+    const movement = controls.update(deltaSec);
+    solarGroup.position.sub(movement);
     // Update grabbing for each hand
     for (let i = 0; i < 2; i++) {
       const hand = renderer.xr.getHand(i);


### PR DESCRIPTION
## Summary
- expose `MAX_FLIGHT_SPEED` constant
- drive throttle and joystick from fingertip position
- return movement vector from `controls.update`
- translate the solar group according to player motion

## Testing
- `node --check scripts/constants.js`
- `node --check scripts/controls.js`
- `node --check scripts/main.js`


------
https://chatgpt.com/codex/tasks/task_e_6882568a1ee88331b6a6b5a18c409b2b