### PR TITLE
Add time control slider

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -13,6 +13,7 @@ import { createControls } from './controls.js';
 import { createOrrery, updateOrrery } from './orrery.js';
 import { launchProbe, updateProbes } from './probes.js';
 import { initAudio } from './audio.js';
+import { setTimeMultiplier } from './constants.js';
 
 
 async function main() {
@@ -98,6 +99,9 @@ async function main() {
     onWarp: index => warpToBody(index),
     onProbeChange: settings => {
       probeSettings = settings;
+    },
+    onTimeChange: value => {
+      setTimeMultiplier(Math.pow(1000, value) - 1);
     },
     onNarrate: fact => audio.speak(fact)
   });


### PR DESCRIPTION
## Summary
- extend the probe control panel with a new Time slider
- emit `onTimeChange` from the UI when the slider moves
- map slider value to time multiplier in `main.js`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6882612514c483318e29875cdc7db6ce