### PR TITLE
Improve XR compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,8 @@
   <script type="importmap">
   {
     "imports": {
-      "three": "https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js",
-      "three/examples/jsm/": "https://cdn.jsdelivr.net/npm/three@0.165.0/examples/jsm/"
+      "three": "https://cdn.jsdelivr.net/npm/three@0.178.0/build/three.module.js",
+      "three/examples/jsm/": "https://cdn.jsdelivr.net/npm/three@0.178.0/examples/jsm/"
     }
   }
   </script>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -24,6 +24,12 @@ async function main() {
   const renderer = new THREE.WebGLRenderer({ antialias: true });
   renderer.setSize(window.innerWidth, window.innerHeight);
   renderer.xr.enabled = true;
+  // Ensure correct colour space on modern browsers
+  renderer.outputColorSpace = THREE.SRGBColorSpace;
+  // Request hand-tracking support if available
+  renderer.xr.setSessionInit({
+    optionalFeatures: ['local-floor', 'bounded-floor', 'hand-tracking']
+  });
   document.body.appendChild(renderer.domElement);
   document.body.style.backgroundImage = 'none';
   


### PR DESCRIPTION
## Summary
- update three.js to 0.178.0
- enable hand tracking in the WebXR session
- set renderer output colour space for modern browsers

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_688392e592808331883ca78aaad10edb