### PR TITLE
Fix undefined clock before animation loop

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -24,6 +24,8 @@ async function main() {
   const renderer = new THREE.WebGLRenderer({ antialias: true });
   renderer.setSize(window.innerWidth, window.innerHeight);
   renderer.xr.enabled = true;
+  // Initialize the clock before the animation loop starts
+  renderer.clock = new THREE.Clock();
   // Ensure correct colour space on modern browsers
   renderer.outputColorSpace = THREE.SRGBColorSpace;
   // Request hand-tracking support if available


### PR DESCRIPTION
## Summary
- initialize `renderer.clock` in main so animation loop runs before VR session

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883956acb808331bdc98413f06b5dd4