### PR TITLE
Fix probe origin relative to solar system

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -70,7 +70,8 @@ async function main() {
   orrery.group.add(playerMarker);
 
   const probes = createProbes();
-  scene.add(probes.group);
+  // Attach probes to the solar system so they travel with it when warping
+  solarGroup.add(probes.group);
   let probeSettings = { mass: 0.5, velocity: 0.5 };
 
   const ui = createUI(bodies, {
@@ -108,8 +109,8 @@ async function main() {
   renderer.xr.addEventListener('sessionstart', () => {
     controls = setupControls(renderer, scene, camera, cockpit, ui, () => {
       const muzzlePos = cockpit.launcherMuzzle.getWorldPosition(new THREE.Vector3());
-      const solarOrigin = solarGroup.getWorldPosition(new THREE.Vector3());
-      const launchPos = muzzlePos.clone().sub(solarOrigin);
+      // Convert to solar system local coordinates so probes spawn at the muzzle
+      const launchPos = solarGroup.worldToLocal(muzzlePos.clone());
       const launchDir = new THREE.Vector3();
       cockpit.launcherMuzzle.getWorldDirection(launchDir);
       launchProbe(probes, launchPos, launchDir, probeSettings.mass, probeSettings.velocity);


### PR DESCRIPTION
## Summary
- keep launched probes parented to the solar system so they move with warps
- calculate probe spawn position relative to the solar system root

## Testing
- `node --check scripts/main.js`
- `for f in scripts/*.js; do node --check $f || break; done`

------
https://chatgpt.com/codex/tasks/task_e_6883aa8e78048331a02db02296b512d4